### PR TITLE
Update packages

### DIFF
--- a/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/Features/CreateCategoryFeature.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/Features/CreateCategoryFeature.cs
@@ -1,8 +1,10 @@
-﻿using Xbehave;
+﻿using TestStack.BDDfy;
+using Xunit;
 using xxAMIDOxx.xxSTACKSxx.API.ComponentTests.Fixtures;
 
 namespace xxAMIDOxx.xxSTACKSxx.API.ComponentTests.Features;
 
+[Trait("TestType", "ComponentTests")]
 public class CreateCategoryFeature
 {
     /* SCENARIOS: Create a category in the menu
@@ -20,86 +22,95 @@ public class CreateCategoryFeature
 
     */
 
-    [Scenario]
+    [Theory]
     [CustomInlineAutoData("Admin")]
     [CustomInlineAutoData("Employee")]
     public void CreateCategoryShouldSucceed(string role, CreateCategoryFixture fixture)
     {
-        $"Given the user is authenticated and has the {role} role".x(() => fixture.GivenTheUserIsAuthenticatedAndHasRole(role));
-        "And an existing menu".x(fixture.GivenAnExistingMenu);
-        "And the menu belongs to the user restaurant".x(fixture.GivenTheMenuBelongsToUserRestaurant);
-        "And the category being created does not exist in the menu".x(fixture.GivenTheCategoryDoesNotExist);
-        "When a new category is submitted".x(fixture.WhenTheCategoryIsSubmitted);
-        "Then a successful response is returned".x(fixture.ThenASuccessfulResponseIsReturned);
-        "And the menu is loaded from the storage".x(fixture.ThenMenuIsLoadedFromStorage);
-        "And the id of the new category is returned".x(fixture.ThenTheResourceCreatedResponseIsReturned);
-        "And the category is added to the menu".x(fixture.ThenTheCategoryIsAddedToMenu);
-        "And the menu is persisted to the storage".x(fixture.ThenTheMenuShouldBePersisted);
-        "And the event MenuUpdate is Raised".x(fixture.ThenAMenuUpdatedEventIsRaised);
-        "And the event CategoryCreated is Raised".x(fixture.ThenACategoryCreatedEventIsRaised);
+        this.Given(_   => fixture.GivenTheUserIsAuthenticatedAndHasRole(role), $"Given the user is authenticated and has the {role} role")
+                .And(_ => fixture.GivenAnExistingMenu(), "And an existing menu")
+                .And(_ => fixture.GivenTheMenuBelongsToUserRestaurant(), "And the menu belongs to the user restaurant")
+                .And(_ => fixture.GivenTheCategoryDoesNotExist(), "And the category being created does not exist in the menu")
+            .When(_    => fixture.WhenTheCategoryIsSubmitted(), "When a new category is submitted")
+            .Then(_    => fixture.ThenASuccessfulResponseIsReturned(), "Then a successful response is returned")
+                .And(_ => fixture.ThenMenuIsLoadedFromStorage(), "And the menu is loaded from the storage")
+                .And(_ => fixture.ThenTheResourceCreatedResponseIsReturned(), "And the id of the new category is returned")
+                .And(_ => fixture.ThenTheCategoryIsAddedToMenu(), "And the category is added to the menu")
+                .And(_ => fixture.ThenTheMenuShouldBePersisted(), "And the menu is persisted to the storage")
+                .And(_ => fixture.ThenAMenuUpdatedEventIsRaised(), "And the event MenuUpdate is Raised")
+                .And(_ => fixture.ThenACategoryCreatedEventIsRaised(), "And the event CategoryCreated is Raised.")
+            .BDDfy();
     }
 
-    [Scenario]
+
+    [Theory]
     [CustomInlineAutoData("Admin")]
+    [CustomInlineAutoData("Employee")]
     public void CreateCategoryShouldFailWhenMenuDoesNotExist(string role, CreateCategoryFixture fixture)
     {
-        $"Given the user is authenticated and has the {role} role".x(() => fixture.GivenTheUserIsAuthenticatedAndHasRole(role));
-        "And a menu does not exist".x(fixture.GivenAMenuDoesNotExist);
-        "When a new category is submitted".x(fixture.WhenTheCategoryIsSubmitted);
-        "Then a failure response is returned".x(fixture.ThenAFailureResponseIsReturned);
-        "And the response code is NotFound".x(fixture.ThenANotFoundResponseIsReturned);
-        "And the menu is loaded from the storage".x(fixture.ThenMenuIsLoadedFromStorage);
-        "And the menu is not persisted to the storage".x(fixture.ThenTheMenuShouldNotBePersisted);
-        "And the event MenuUpdate should NOT be raised".x(fixture.ThenAMenuUpdatedEventIsNotRaised);
-        "And the event CategoryCreated should not be Raised".x(fixture.ThenACategoryCreatedEventIsNotRaised);
+        this.Given(_   => fixture.GivenTheUserIsAuthenticatedAndHasRole(role), $"Given the user is authenticated and has the {role} role")
+                .And(_ => fixture.GivenAMenuDoesNotExist(), "And a menu does not exist")
+            .When(_    => fixture.WhenTheCategoryIsSubmitted(), "When a new category is submitted")
+            .Then(_    => fixture.ThenAFailureResponseIsReturned(), "Then a failure response is returned")
+                .And(_ => fixture.ThenANotFoundResponseIsReturned(), "And the response code is NotFound")
+                .And(_ => fixture.ThenTheMenuShouldNotBePersisted(), "And the menu is not persisted to the storage")
+                .And(_ => fixture.ThenAMenuUpdatedEventIsNotRaised(), "And the event MenuUpdate should NOT be raised")
+                .And(_ => fixture.ThenACategoryCreatedEventIsNotRaised(), "And the event CategoryCreated should not be Raised")
+            .BDDfy();
     }
 
-    [Scenario]
+
+    [Theory]
     [CustomInlineAutoData("Admin")]
+    [CustomInlineAutoData("Employee")]
     public void CreateCategoryShouldFailWhenCategoryAlreadyExists(string role, CreateCategoryFixture fixture)
     {
-        $"Given the user is authenticated and has the {role} role".x(() => fixture.GivenTheUserIsAuthenticatedAndHasRole(role));
-        "And an existing menu".x(fixture.GivenAnExistingMenu);
-        "And the menu belongs to the user restaurant".x(fixture.GivenTheMenuBelongsToUserRestaurant);
-        "And the category being created already exist in the menu".x(fixture.GivenTheCategoryAlreadyExist);
-        "When a new category is submitted".x(fixture.WhenTheCategoryIsSubmitted);
-        "Then a failure response is returned".x(fixture.ThenAFailureResponseIsReturned);
-        "And the response code is Conflict".x(fixture.ThenAConflictResponseIsReturned);
-        "And the menu is NOT persisted to the storage".x(fixture.ThenTheMenuShouldNotBePersisted);
-        "And the event MenuUpdate should NOT be raised".x(fixture.ThenAMenuUpdatedEventIsNotRaised);
-        "And the event CategoryCreated is NOT Raised".x(fixture.ThenACategoryCreatedEventIsNotRaised);
+        this.Given(_    => fixture.GivenTheUserIsAuthenticatedAndHasRole(role), $"Given the user is authenticated and has the {role} role")
+                .And(_  => fixture.GivenAnExistingMenu(), "And an existing menu")
+                .And(_  => fixture.GivenTheMenuBelongsToUserRestaurant(), "And the menu belongs to the user restaurant")
+                .And(_  => fixture.GivenTheCategoryAlreadyExist(), "And the category being created already exist in the menu")
+            .When(_     => fixture.WhenTheCategoryIsSubmitted(), "When a new category is submitted")
+            .Then(_     => fixture.ThenAFailureResponseIsReturned(), "Then a failure response is returned")
+                .And(_  => fixture.ThenAConflictResponseIsReturned(), "And the response code is Conflict")
+                .And(_  => fixture.ThenTheMenuShouldNotBePersisted(), "And the menu is NOT persisted to the storage")
+                .And(_  => fixture.ThenAMenuUpdatedEventIsNotRaised(), "And the event MenuUpdate should NOT be raised")
+                .And(_  => fixture.ThenACategoryCreatedEventIsNotRaised(), "And the event CategoryCreated is NOT Raised")
+            .BDDfy();
     }
 
-    [Scenario(Skip = "Disabled until security is implemented")]
+
+    [Theory(Skip = "Disabled until security is implemented")]
     [CustomInlineAutoData("Customer")]
     [CustomInlineAutoData("UnauthenticatedUser")]
     public void CreateCategoryShouldFailWithForbidden(string role, CreateCategoryFixture fixture)
     {
-        $"Given the user is authenticated and has the {role} role".x(() => fixture.GivenTheUserIsAuthenticatedAndHasRole(role));
-        "And an existing menu".x(fixture.GivenAnExistingMenu);
-        "And the category being created does not exist in the menu".x(fixture.GivenTheCategoryDoesNotExist);
-        "When a new category is submitted".x(fixture.WhenTheCategoryIsSubmitted);
-        "Then a Forbidden response is returned".x(fixture.ThenAForbiddenResponseIsReturned);
-        "And the menu is not persisted to the storage".x(fixture.ThenTheMenuShouldNotBePersisted);
-        "And the event MenuUpdate is NOT Raised".x(fixture.ThenAMenuUpdatedEventIsNotRaised);
-        "And the event CategoryCreated is NOT Raised".x(fixture.ThenACategoryCreatedEventIsNotRaised);
+        this.Given(_   => fixture.GivenTheUserIsAuthenticatedAndHasRole(role), $"Given the user is authenticated and has the {role} role")
+                .And(_ => fixture.GivenAnExistingMenu(), "And an existing menu")
+                .And(_ => fixture.GivenTheCategoryDoesNotExist(), "And the category being created does not exist in the menu")
+            .When(_    => fixture.WhenTheCategoryIsSubmitted(), "When a new category is submitted")
+            .Then(_    => fixture.ThenAForbiddenResponseIsReturned(), "Then a Forbidden response is returned")
+                .And(_ => fixture.ThenTheMenuShouldNotBePersisted(), "And the menu is not persisted to the storage")
+                .And(_ => fixture.ThenAMenuUpdatedEventIsNotRaised(), "And the event MenuUpdate is NOT Raised")
+                .And(_ => fixture.ThenACategoryCreatedEventIsNotRaised(), "And the event CategoryCreated is NOT Raised")
+            .BDDfy();
     }
 
 
-    [Scenario(Skip = "Disabled until security is implemented")]
+    [Theory(Skip = "Disabled until security is implemented")]
     [CustomInlineAutoData("Admin")]
     [CustomInlineAutoData("Employee")]
     public void CreateCategoryShouldFailWhenMenuDoesNotBelongToUser(string role, CreateCategoryFixture fixture)
     {
-        $"Given the user is authenticated and has the {role} role".x(() => fixture.GivenTheUserIsAuthenticatedAndHasRole(role));
-        "And an existing menu".x(fixture.GivenAnExistingMenu);
-        "And the menu does not belong to users restaurant".x(fixture.GivenTheMenuDoesNotBelongToUserRestaurant);
-        "When a new category is submitted".x(fixture.WhenTheCategoryIsSubmitted);
-        "Then a failure response is returned".x(fixture.ThenAFailureResponseIsReturned);
-        "And the response code is NotFound".x(fixture.ThenANotFoundResponseIsReturned);
-        "And the menu is loaded from the storage".x(fixture.ThenMenuIsLoadedFromStorage);
-        "And the menu is not persisted to the storage".x(fixture.ThenTheMenuShouldNotBePersisted);
-        "And the event MenuUpdate should not be Raised".x(fixture.ThenAMenuUpdatedEventIsNotRaised);
-        "And the event CategoryCreated should not be Raised".x(fixture.ThenACategoryCreatedEventIsNotRaised);
+        this.Given(_   => fixture.GivenTheUserIsAuthenticatedAndHasRole(role), $"Given the user is authenticated and has the {role} role")
+                .And(_ => fixture.GivenAnExistingMenu(), "And an existing menu")
+                .And(_ => fixture.GivenTheMenuDoesNotBelongToUserRestaurant(), "And the menu does not belong to users restaurant")
+            .When(_    => fixture.WhenTheCategoryIsSubmitted(), "When a new category is submitted")
+            .Then(_    => fixture.ThenAFailureResponseIsReturned(), "Then a failure response is returned")
+                .And(_ => fixture.ThenANotFoundResponseIsReturned(), "And the response code is NotFound")
+                .And(_ => fixture.ThenMenuIsLoadedFromStorage(), "And the menu is loaded from the storage")
+                .And(_ => fixture.ThenTheMenuShouldNotBePersisted(), "And the menu is not persisted to the storage")
+                .And(_ => fixture.ThenAMenuUpdatedEventIsNotRaised(), "And the event MenuUpdate should not be Raised")
+                .And(_ => fixture.ThenACategoryCreatedEventIsNotRaised(), "And the event CategoryCreated should not be Raised")
+            .BDDfy();
     }
 }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/Features/CreateMenuFeature.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/Features/CreateMenuFeature.cs
@@ -1,5 +1,5 @@
-﻿using xxAMIDOxx.xxSTACKSxx.CQRS.ApplicationEvents;
-using Xbehave;
+﻿using TestStack.BDDfy;
+using xxAMIDOxx.xxSTACKSxx.CQRS.ApplicationEvents;
 using Xunit;
 using xxAMIDOxx.xxSTACKSxx.API.ComponentTests.Fixtures;
 
@@ -21,42 +21,47 @@ public class CreateMenuFeature
 
     */
 
-    [Scenario, CustomAutoData]
+    [Theory, CustomAutoData]
     public void CreateMenuAsAdminForValidMenuShouldSucceed(CreateMenuFixture fixture)
     {
-        "Given the user is authenticated and has the Admin role".x(() => fixture.GivenTheUserIsAnAuthenticatedAdministrator());
-        "And the menu does not does not exist".x(fixture.GivenAMenuDoesNotExist);
-        "When the menu is submitted".x(fixture.WhenTheMenuCreationIsSubmitted);
-        "Then a successful response is returned".x(fixture.ThenASuccessfulResponseIsReturned);
-        "And the response code is CREATED".x(fixture.ThenACreatedResponseIsReturned);
-        "And the id of the new menu is returned".x(fixture.ThenTheResourceCreatedResponseIsReturned);
-        "And the menu data is submitted correctly to the database".x(fixture.ThenTheMenuIsSubmittedToDatabase);
-        $"And an event of type {nameof(MenuCreatedEvent)} is raised".x(fixture.ThenAMenuCreatedEventIsRaised);
+        this.Given(_   => fixture.GivenTheUserIsAnAuthenticatedAdministrator(), "Given the user is authenticated and has the Admin role")
+                .And(_ => fixture.GivenAMenuDoesNotExist(), "And the menu does not does not exist")
+            .When(_    => fixture.WhenTheMenuCreationIsSubmitted(), "When the menu is submitted")
+            .Then(_    => fixture.ThenASuccessfulResponseIsReturned(), "Then a successful response is returned")
+                .And(_ => fixture.ThenACreatedResponseIsReturned(), "And the response code is CREATED")
+                .And(_ => fixture.ThenTheResourceCreatedResponseIsReturned(), "And the id of the new menu is returned")
+                .And(_ => fixture.ThenTheMenuIsSubmittedToDatabase(), "And the menu data is submitted correctly to the database")
+                .And(_ => fixture.ThenAMenuCreatedEventIsRaised(), $"And an event of type {nameof(MenuCreatedEvent)} is raised")
+            .BDDfy();
     }
 
-    [Scenario, CustomAutoData]
+
+    [Theory, CustomAutoData]
     public void CreateMenuAsAdminForInvalidMenuShouldFail(CreateMenuFixture fixture)
     {
-        "Given the user is authenticated and has the Admin role".x(() => fixture.GivenTheUserIsAnAuthenticatedAdministrator());
-        "And a valid menu being submitted".x(fixture.GivenAInvalidMenu);
-        "And the menu does not does not exist".x(fixture.GivenAMenuDoesNotExist);
-        "When the menu is submitted".x(fixture.WhenTheMenuCreationIsSubmitted);
-        "Then a failure response is returned".x(fixture.ThenAFailureResponseIsReturned);
-        "And the menu is not submitted to the database".x(fixture.ThenTheMenuIsNotSubmittedToDatabase);
-        $"And an event of type {nameof(MenuCreatedEvent)} should not be raised".x(fixture.ThenAMenuCreatedEventIsNotRaised);
+        this.Given(_   => fixture.GivenTheUserIsAnAuthenticatedAdministrator(), "Given the user is authenticated and has the Admin role")
+                .And(_ => fixture.GivenAInvalidMenu(), "And a valid menu being submitted")
+                .And(_ => fixture.GivenAMenuDoesNotExist(), "And the menu does not does not exist")
+            .When(_    => fixture.WhenTheMenuCreationIsSubmitted(), "When the menu is submitted")
+            .Then(_    => fixture.ThenAFailureResponseIsReturned(), "Then a failure response is returned")
+                .And(_ => fixture.ThenTheMenuIsNotSubmittedToDatabase(), "And the menu is not submitted to the database")
+                .And(_ => fixture.ThenAMenuCreatedEventIsNotRaised(), $"And an event of type {nameof(MenuCreatedEvent)} should not be raised")
+            .BDDfy();
     }
 
-    [Scenario(Skip = "Only works when Auth is implemented")]
+
+    [Theory(Skip = "Only works when Auth is implemented")]
     [CustomInlineAutoData("Employee")]
     [CustomInlineAutoData("Customer")]
     [CustomInlineAutoData("UnauthenticatedUser")]
     public void CreateMenuAsNonAdminForValidMenuShouldFail(string role, CreateMenuFixture fixture)
     {
-        $"Given the user is authenticated and has the {role} role".x(() => fixture.GivenTheUserIsAuthenticatedAndHasRole(role));
-        "And the menu does not does not exist".x(fixture.GivenAMenuDoesNotExist);
-        "When the menu is submitted".x(fixture.WhenTheMenuCreationIsSubmitted);
-        "Then a Forbidden response is returned".x(fixture.ThenAForbiddenResponseIsReturned);
-        "And the menu is not submitted to the database".x(fixture.ThenTheMenuIsNotSubmittedToDatabase);
-        $"And an event of type {nameof(MenuCreatedEvent)} should not be raised".x(fixture.ThenAMenuCreatedEventIsNotRaised);
+        this.Given(_   => fixture.GivenTheUserIsAuthenticatedAndHasRole(role), $"Given the user is authenticated and has the {role} role")
+                .And(_ => fixture.GivenAMenuDoesNotExist(), "And the menu does not does not exist")
+            .When(_    => fixture.WhenTheMenuCreationIsSubmitted(), "When the menu is submitted")
+            .Then(_    => fixture.ThenAForbiddenResponseIsReturned(), "Then a Forbidden response is returned")
+                .And(_ => fixture.ThenTheMenuIsNotSubmittedToDatabase(), "And the menu is not submitted to the database")
+                .And(_ => fixture.ThenAMenuCreatedEventIsNotRaised(), $"And an event of type {nameof(MenuCreatedEvent)} should not be raised")
+            .BDDfy();
     }
 }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/xxAMIDOxx.xxSTACKSxx.API.ComponentTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/xxAMIDOxx.xxSTACKSxx.API.ComponentTests.csproj
@@ -7,19 +7,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Testing" Version="0.2.22" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Amido.Stacks.Testing" Version="0.2.29" />
         <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
-        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.23" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.25" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="System.DirectoryServices.Protocols" Version="6.0.2" />
-        <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="Xbehave" Version="2.4.1" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
+        <PackageReference Include="xunit" Version="2.6.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/xxAMIDOxx.xxSTACKSxx.API.ComponentTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/xxAMIDOxx.xxSTACKSxx.API.ComponentTests.csproj
@@ -7,23 +7,23 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Testing" Version="0.2.20" />
-        <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="NSubstitute" Version="4.3.0" />
-        <PackageReference Include="Shouldly" Version="4.0.3" />
-        <PackageReference Include="System.DirectoryServices.Protocols" Version="6.0.1" />
+        <PackageReference Include="Amido.Stacks.Testing" Version="0.2.22" />
+        <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.23" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
+        <PackageReference Include="System.DirectoryServices.Protocols" Version="6.0.2" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Include="Xbehave" Version="2.4.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API.ContractTests/xxAMIDOxx.xxSTACKSxx.API.ContractTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API.ContractTests/xxAMIDOxx.xxSTACKSxx.API.ContractTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -7,21 +7,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Testing" Version="0.2.20" />
+        <PackageReference Include="Amido.Stacks.Testing" Version="0.2.22" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-        <PackageReference Include="AutoFixture" Version="4.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="NSubstitute" Version="4.3.0" />
+        <PackageReference Include="AutoFixture" Version="4.18.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="PactNet.Windows" Version="3.0.2" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API.ContractTests/xxAMIDOxx.xxSTACKSxx.API.ContractTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API.ContractTests/xxAMIDOxx.xxSTACKSxx.API.ContractTests.csproj
@@ -7,16 +7,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Testing" Version="0.2.22" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Amido.Stacks.Testing" Version="0.2.29" />
         <PackageReference Include="AutoFixture" Version="4.18.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="PactNet.Windows" Version="3.0.2" />
-        <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API.UnitTests/xxAMIDOxx.xxSTACKSxx.API.UnitTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API.UnitTests/xxAMIDOxx.xxSTACKSxx.API.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -8,15 +8,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="NSubstitute" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API.UnitTests/xxAMIDOxx.xxSTACKSxx.API.UnitTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API.UnitTests/xxAMIDOxx.xxSTACKSxx.API.UnitTests.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API/Startup.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API/Startup.cs
@@ -62,19 +62,23 @@ public class Startup
         if (useOpenTelemetry)
         {
             AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-            services.AddOpenTelemetryTracing((builder) => builder
-                .SetResourceBuilder(ResourceBuilder.CreateDefault()
-                    .AddService(Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.OtlpServiceName)))
-                .AddAspNetCoreInstrumentation()
-                .AddConsoleExporter(options =>
-                {
-                    options.Targets = ConsoleExporterOutputTargets.Debug;
-                })
-                .AddOtlpExporter(otlpOptions =>
-                {
-                    otlpOptions.Endpoint =
-                        new Uri(Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.OltpEndpoint));
-                }));
+            services.AddOpenTelemetry()
+                    .WithTracing(builder =>
+                    {
+                        builder.ConfigureResource(resource =>
+                        {
+                            resource.AddService(Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.OtlpServiceName));
+                        });
+                        builder.AddAspNetCoreInstrumentation();
+                        builder.AddConsoleExporter(options =>
+                        {
+                            options.Targets = ConsoleExporterOutputTargets.Debug;
+                        });
+                        builder.AddOtlpExporter(options =>
+                        {
+                            options.Endpoint = new Uri(Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.OltpEndpoint));
+                        });
+                    });
         }
 
         services.AddHealthChecks();

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API/appsettings.json
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API/appsettings.json
@@ -15,7 +15,7 @@
             {
                 "Name": "ApplicationInsights",
                 "Args": {
-                    "telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
+                    "telemetryConverter": "Serilog.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
                 }
             }
         ],

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API/xxAMIDOxx.xxSTACKSxx.API.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API/xxAMIDOxx.xxSTACKSxx.API.csproj
@@ -16,10 +16,10 @@
     </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.API" Version="0.2.24" />
+    <PackageReference Include="Amido.Stacks.API" Version="0.2.26" />
     <PackageReference Include="Amido.Stacks.API.Swagger" Version="0.2.35" />
-    <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.23" />
+    <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.23" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.25" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
@@ -28,11 +28,11 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-    <PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API/xxAMIDOxx.xxSTACKSxx.API.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API/xxAMIDOxx.xxSTACKSxx.API.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -16,30 +16,30 @@
     </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.API" Version="0.2.21" />
-    <PackageReference Include="Amido.Stacks.API.Swagger" Version="0.2.33" />
-    <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.17" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.2.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.2.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.2.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Amido.Stacks.API" Version="0.2.24" />
+    <PackageReference Include="Amido.Stacks.API.Swagger" Version="0.2.35" />
+    <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.23" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\xxAMIDOxx.xxSTACKSxx.Domain\xxAMIDOxx.xxSTACKSxx.Domain.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
-    <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.29" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.43" />
+    <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.93" />
   </ItemGroup>
 </Project>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\xxAMIDOxx.xxSTACKSxx.Domain\xxAMIDOxx.xxSTACKSxx.Domain.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.43" />
-    <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.93" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.75" />
+    <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.95" />
   </ItemGroup>
 </Project>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Application.QueryHandlers/xxAMIDOxx.xxSTACKSxx.Application.QueryHandlers.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Application.QueryHandlers/xxAMIDOxx.xxSTACKSxx.Application.QueryHandlers.csproj
@@ -12,6 +12,6 @@
 
     <ItemGroup>
         <PackageReference Include="Amido.Stacks.Data.Documents.Abstractions" Version="0.2.15" />
-        <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.93" />
+        <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.95" />
     </ItemGroup>
 </Project>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Application.QueryHandlers/xxAMIDOxx.xxSTACKSxx.Application.QueryHandlers.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Application.QueryHandlers/xxAMIDOxx.xxSTACKSxx.Application.QueryHandlers.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Data.Documents.Abstractions" Version="0.2.13" />
-        <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.29" />
+        <PackageReference Include="Amido.Stacks.Data.Documents.Abstractions" Version="0.2.15" />
+        <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.93" />
     </ItemGroup>
 </Project>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests.csproj
@@ -9,13 +9,13 @@
     <ItemGroup>
         <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.21" />
         <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="System.DirectoryServices.Protocols" Version="6.0.2" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
-        <PackageReference Include="System.DirectoryServices.Protocols" Version="7.0.1" />
+        <PackageReference Include="System.DirectoryServices.Protocols" Version="6.0.2" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Include="xunit" Version="2.5.3" />

--- a/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests.csproj
@@ -7,20 +7,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.19" />
-        <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="NSubstitute" Version="4.3.0" />
-        <PackageReference Include="Shouldly" Version="4.0.3" />
-        <PackageReference Include="System.DirectoryServices.Protocols" Version="6.0.1" />
+        <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.21" />
+        <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
+        <PackageReference Include="System.DirectoryServices.Protocols" Version="7.0.1" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.CQRS/xxAMIDOxx.xxSTACKSxx.CQRS.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.CQRS/xxAMIDOxx.xxSTACKSxx.CQRS.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.17" />
+        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.CQRS/xxAMIDOxx.xxSTACKSxx.CQRS.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.CQRS/xxAMIDOxx.xxSTACKSxx.CQRS.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
+        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.23" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Common.UnitTests/xxAMIDOxx.xxSTACKSxx.Common.UnitTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Common.UnitTests/xxAMIDOxx.xxSTACKSxx.Common.UnitTests.csproj
@@ -7,10 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Common.UnitTests/xxAMIDOxx.xxSTACKSxx.Common.UnitTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Common.UnitTests/xxAMIDOxx.xxSTACKSxx.Common.UnitTests.csproj
@@ -7,15 +7,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Common/xxAMIDOxx.xxSTACKSxx.Common.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Common/xxAMIDOxx.xxSTACKSxx.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Core" Version="0.2.19" />
+        <PackageReference Include="Amido.Stacks.Core" Version="0.2.21" />
     </ItemGroup>
     <ItemGroup>
         <Folder Include="Configuration\" />

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Common/xxAMIDOxx.xxSTACKSxx.Common.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Common/xxAMIDOxx.xxSTACKSxx.Common.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Core" Version="0.2.21" />
+        <PackageReference Include="Amido.Stacks.Core" Version="0.2.35" />
     </ItemGroup>
     <ItemGroup>
         <Folder Include="Configuration\" />

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests.csproj
@@ -9,10 +9,10 @@
     <ItemGroup>
         <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests.csproj
@@ -7,17 +7,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Domain/xxAMIDOxx.xxSTACKSxx.Domain.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Domain/xxAMIDOxx.xxSTACKSxx.Domain.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Domain" Version="0.2.17" />
-        <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.93" />
+        <PackageReference Include="Amido.Stacks.Domain" Version="0.2.19" />
+        <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.95" />
     </ItemGroup>
 </Project>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Domain/xxAMIDOxx.xxSTACKSxx.Domain.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Domain/xxAMIDOxx.xxSTACKSxx.Domain.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Domain" Version="0.2.15" />
-        <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.29" />
+        <PackageReference Include="Amido.Stacks.Domain" Version="0.2.17" />
+        <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.93" />
     </ItemGroup>
 </Project>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests.csproj
@@ -22,16 +22,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.53" />
-        <PackageReference Include="Amido.Stacks.Testing" Version="0.2.22" />
+        <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.56" />
+        <PackageReference Include="Amido.Stacks.Testing" Version="0.2.29" />
         <PackageReference Include="AutoFixture" Version="4.18.0" />
         <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests.csproj
@@ -22,21 +22,21 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.50" />
-        <PackageReference Include="Amido.Stacks.Testing" Version="0.2.20" />
-        <PackageReference Include="AutoFixture" Version="4.17.0" />
-        <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="NSubstitute" Version="4.3.0" />
+        <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.53" />
+        <PackageReference Include="Amido.Stacks.Testing" Version="0.2.22" />
+        <PackageReference Include="AutoFixture" Version="4.18.0" />
+        <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -8,15 +8,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.6.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="NSubstitute" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
@@ -6,19 +6,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.45" />
-    <PackageReference Include="Amido.Stacks.Messaging.AWS.SNS" Version="0.2.3" />
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.6-preview-master" />
-    <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.19" />
+    <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.53" />
+    <PackageReference Include="Amido.Stacks.Messaging.AWS.SNS" Version="0.2.70" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.43" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.30" />
+    <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.21" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />
-    <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.29" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.15"/>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.23" />
+    <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.93" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.203.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
@@ -6,20 +6,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.53" />
-    <PackageReference Include="Amido.Stacks.Messaging.AWS.SNS" Version="0.2.70" />
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.43" />
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.30" />
+    <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.56" />
+    <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.95" />
+    <PackageReference Include="Amido.Stacks.Messaging.AWS.SNS" Version="0.2.72" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.75" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.32" />
     <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.21" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.300.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.23" />
-    <PackageReference Include="Amido.Stacks.DynamoDB" Version="0.2.93" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.203.5" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.25" />
   </ItemGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers\xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers.csproj" />

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.17" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
 </Project>

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
+        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.23" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/StacksListenerTests.cs
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/StacksListenerTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Amido.Stacks.Messaging.Azure.EventHub.Serializers;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using NSubstitute;

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
@@ -7,16 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.12-preview-master" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.30" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.30" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.32" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/StacksListener.cs
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/StacksListener.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Amido.Stacks.Messaging.Azure.EventHub.Serializers;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events;

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/appsettings.json
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/appsettings.json
@@ -1,4 +1,4 @@
-{
+﻿{
 	"Serilog": {
 		"Using": [
 			"Serilog.Sinks.Console",
@@ -13,9 +13,9 @@
 			},
 			{
 				"Name": "ApplicationInsights",
-				"Args": {
-					"telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
-				}
+                "Args": {
+                    "telemetryConverter": "Serilog.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
+                }
 			}
 		],
 		"Enrich": [

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
@@ -4,16 +4,16 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.7-preview-master" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.30" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.2" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="6.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
@@ -32,6 +32,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <FunctionsPreservedDependencies Include="Microsoft.Extensions.DependencyModel.dll"/>
+    <FunctionsPreservedDependencies Include="Microsoft.Extensions.DependencyModel.dll" />
   </ItemGroup>
 </Project>

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
@@ -4,16 +4,16 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.30" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.2" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="6.0.1" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.32" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.10.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
@@ -25,10 +25,6 @@
     </None>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.17" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
 </Project>

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
+        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.23" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/StacksListenerTests.cs
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/StacksListenerTests.cs
@@ -29,7 +29,7 @@ public class StacksListenerTests
         var msgBody = BuildMessageBody();
         var message = BuildMessage(msgBody);
 
-        var stacksListener = new StacksListener(msgReader, logger);
+        var stacksListener = new StacksListener(logger);
 
         stacksListener.Run(message);
 

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
@@ -7,16 +7,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="NSubstitute" Version="4.2.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/appsettings.json
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/appsettings.json
@@ -1,4 +1,4 @@
-{
+﻿{
 	"Serilog": {
 		"Using": [
 			"Serilog.Sinks.Console",
@@ -13,9 +13,9 @@
 			},
 			{
 				"Name": "ApplicationInsights",
-				"Args": {
-					"telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
-				}
+                "Args": {
+                    "telemetryConverter": "Serilog.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
+                }
 			}
 		],
 		"Enrich": [

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
@@ -4,15 +4,15 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.2" />
-	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.43" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.4" />
+	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.75" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	<PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
 	<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events\xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj" />
@@ -24,10 +24,6 @@
     </None>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
@@ -4,15 +4,15 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.2.0" />
-	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
-	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.2" />
+	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.43" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
+	<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	<PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
 	<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events\xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj" />
@@ -31,6 +31,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <FunctionsPreservedDependencies Include="Microsoft.Extensions.DependencyModel.dll"/>
+    <FunctionsPreservedDependencies Include="Microsoft.Extensions.DependencyModel.dll" />
   </ItemGroup>
 </Project>

--- a/src/functions/func-cosmosdb-worker/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
+++ b/src/functions/func-cosmosdb-worker/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.17" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
 </Project>

--- a/src/functions/func-cosmosdb-worker/xxAMIDOxx.xxSTACKSxx.Worker.UnitTests/xxAMIDOxx.xxSTACKSxx.Worker.UnitTests.csproj
+++ b/src/functions/func-cosmosdb-worker/xxAMIDOxx.xxSTACKSxx.Worker.UnitTests/xxAMIDOxx.xxSTACKSxx.Worker.UnitTests.csproj
@@ -7,16 +7,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="NSubstitute" Version="4.2.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/functions/func-cosmosdb-worker/xxAMIDOxx.xxSTACKSxx.Worker/ChangeFeedListener.cs
+++ b/src/functions/func-cosmosdb-worker/xxAMIDOxx.xxSTACKSxx.Worker/ChangeFeedListener.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Amido.Stacks.Application.CQRS.ApplicationEvents;
-using Microsoft.Azure.Documents;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events;
@@ -24,23 +23,23 @@ public class ChangeFeedListener
     [FunctionName(Constants.FunctionNames.CosmosDbChangeFeedListener)]
     public void Run([CosmosDBTrigger(
         databaseName: "%COSMOSDB_DATABASE_NAME%",
-        collectionName: "%COSMOSDB_COLLECTION_NAME%",
-        ConnectionStringSetting = "COSMOSDB_CONNECTIONSTRING",
-        LeaseCollectionName = "%COSMOSDB_LEASE_COLLECTION_NAME%",
-        CreateLeaseCollectionIfNotExists = true)]IReadOnlyList<Document> input)
+        containerName: "%COSMOSDB_COLLECTION_NAME%",
+        Connection  = "COSMOSDB_CONNECTIONSTRING",
+        LeaseContainerName  = "%COSMOSDB_LEASE_COLLECTION_NAME%",
+        CreateLeaseContainerIfNotExists  = true)]IReadOnlyList<CosmosDbChangeFeedEvent> input)
     {
         if (input != null && input.Count > 0)
         {
             logger.LogInformation("Documents modified " + input.Count);
             foreach (var changedItem in input)
             {
-                logger.LogInformation("Document read. Id: " + changedItem.Id);
+                logger.LogInformation("Document read. Id: " + changedItem.EntityId);
 
                 var cosmosDbEvent = new CosmosDbChangeFeedEvent(
                     operationCode: 999,
                     correlationId: Guid.NewGuid(),
-                    Guid.Parse(changedItem.Id),
-                    changedItem.ETag);
+                    entityId: changedItem.EntityId,
+                    eTag: changedItem.ETag);
 
                 appEventPublisher.PublishAsync(cosmosDbEvent);
             }

--- a/src/functions/func-cosmosdb-worker/xxAMIDOxx.xxSTACKSxx.Worker/appsettings.json
+++ b/src/functions/func-cosmosdb-worker/xxAMIDOxx.xxSTACKSxx.Worker/appsettings.json
@@ -13,9 +13,9 @@
 			},
 			{
 				"Name": "ApplicationInsights",
-				"Args": {
-					"telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
-				}
+                "Args": {
+                    "telemetryConverter": "Serilog.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
+                }
 			}
 		],
 		"Enrich": [

--- a/src/functions/func-cosmosdb-worker/xxAMIDOxx.xxSTACKSxx.Worker/xxAMIDOxx.xxSTACKSxx.Worker.csproj
+++ b/src/functions/func-cosmosdb-worker/xxAMIDOxx.xxSTACKSxx.Worker/xxAMIDOxx.xxSTACKSxx.Worker.csproj
@@ -4,17 +4,28 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.10" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="4.4.0" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.23" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.43" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events\xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj" />
@@ -33,6 +44,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <FunctionsPreservedDependencies Include="Microsoft.Extensions.DependencyModel.dll"/>
+    <FunctionsPreservedDependencies Include="Microsoft.Extensions.DependencyModel.dll" />
   </ItemGroup>
 </Project>

--- a/src/functions/func-cosmosdb-worker/xxAMIDOxx.xxSTACKSxx.Worker/xxAMIDOxx.xxSTACKSxx.Worker.csproj
+++ b/src/functions/func-cosmosdb-worker/xxAMIDOxx.xxSTACKSxx.Worker/xxAMIDOxx.xxSTACKSxx.Worker.csproj
@@ -38,10 +38,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <FunctionsPreservedDependencies Include="Microsoft.Extensions.DependencyModel.dll" />

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.csproj
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.csproj
@@ -8,17 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.csproj
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -14,10 +14,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
-    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/worker/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
+++ b/src/worker/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.17" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 </Project>

--- a/src/worker/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
+++ b/src/worker/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events/xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
+        <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.23" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 </Project>

--- a/src/worker/xxAMIDOxx.xxSTACKSxx.BackgroundWorker/appsettings.json
+++ b/src/worker/xxAMIDOxx.xxSTACKSxx.BackgroundWorker/appsettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
 	"Serilog": {
 		"Using": [
 			"Serilog.Sinks.Console",
@@ -14,9 +14,9 @@
 			},
 			{
 				"Name": "ApplicationInsights",
-				"Args": {
-					"telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
-				}
+                "Args": {
+                    "telemetryConverter": "Serilog.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
+                }
 			}
 		],
 		"Enrich": [

--- a/src/worker/xxAMIDOxx.xxSTACKSxx.BackgroundWorker/xxAMIDOxx.xxSTACKSxx.BackgroundWorker.csproj
+++ b/src/worker/xxAMIDOxx.xxSTACKSxx.BackgroundWorker/xxAMIDOxx.xxSTACKSxx.BackgroundWorker.csproj
@@ -15,12 +15,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.43" />
-	<PackageReference Include="Serilog" Version="3.0.1" />
+	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.75" />
+	<PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/worker/xxAMIDOxx.xxSTACKSxx.BackgroundWorker/xxAMIDOxx.xxSTACKSxx.BackgroundWorker.csproj
+++ b/src/worker/xxAMIDOxx.xxSTACKSxx.BackgroundWorker/xxAMIDOxx.xxSTACKSxx.BackgroundWorker.csproj
@@ -14,14 +14,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.49" />
-	<PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.3.43" />
+	<PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Update packages

#### 📲 What

Updating .NET packages to their latest .NET 6 releases and third-party packages to their latest releases.  This includes all solutions in the repository:  The API project, all three Azure Functions projects, the Functional Tests project and the Worker project.

Some package updates have led to minor code changes, these are discussed in the 'How' section below.  Xbehave has been deprecated and was blocking updates to the most recent xUnit packages, so it has been swapped for BDDfy.  BDDfy was chosen for consistency because it is used in other Stacks projects.  

#### 🤔 Why

Package updates have been requested for .NET and Java Stacks as part of the latest Stacks cycle.

#### 🛠 How

* Simple package updates in all csproj files.
* Replace Xbhave with Bddfy in API Component Tests:  Fixtures and steps are unchanged, but the scenarios in the Features file have been updated from Xbehave scenarios to BDDfy scenarios with comments preserved.
* Failing Tests:  The Azure Service Bus Listener's test project would not compile, adjusted the method call for the StacksListener class in the unit test project so it has the correct number of parameters and now it compiles and passes.
* Breaking changes for Serilog:  The Application Insights sink's namespace had to be updated in the appsettings.json files.
* Breaking changes for Open Telemetry: The service collection builder has been adjusted for the new fluent builder methods.
* Breaking changes for CosmosDB Azure Function Trigger:  The input parameters for the CosmosDB's change feed trigger have been adjusted in the later packages, so these have been updated.

#### 👀 Evidence

*  See csproj file changes in the 'Files Changed' tab for package updates.
* Regarding Serilog and Open Telemetry, the screenshots below show that after making the configuration changes discussed above, both Application Insights and Open Telemetry, via Jaeger, still receive logs.
* Regarding the CosmosDB trigger the screenshot below shows how change feed events are still triggered after the parameters have been updated.

![application-insights](https://github.com/Ensono/stacks-dotnet-cqrs/assets/832372/92ed2d48-b2df-4074-84a5-536feb0935a3)
![open-telemetry-with-jaeger](https://github.com/Ensono/stacks-dotnet-cqrs/assets/832372/24ec02e4-e660-485e-bdc4-dd8c86e9789b)
![cosmosdb-change-feed-trigger](https://github.com/Ensono/stacks-dotnet-cqrs/assets/832372/bd05c614-554e-452f-95f0-aa591d84697c)

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
