### PR TITLE
Update global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
 	"sdk": {
-		"version": "6.0.300"
+		"version": "6.0.300",
+		"rollForward": "latestPatch"
 	}
 }


### PR DESCRIPTION
#### 📲 What

Modify the version constraint so that later patch versions of the .NET SDK are supported

#### 🤔 Why
		
Prevbiously the project was being contsrained to a specific version number, however this meant that the Ensono Stacks Docker images had to have that specific version of .NET and did not easily allow newer versions.
		
#### 🛠 How
		
Updated the `global.json` to allow later patch version numbers.

#### 👀 Evidence
		
```
{
	"sdk": {
		"version": "6.0.300",
		"rollForward": "latestPatch"
	}
}
```
		 

